### PR TITLE
Move DummyUpdater over to Qsor.Game

### DIFF
--- a/Qsor.Desktop/Program.cs
+++ b/Qsor.Desktop/Program.cs
@@ -13,9 +13,7 @@ namespace Qsor.Desktop
             using var host = Host.GetSuitableHost("Qsor");
             using var game = new QsorGame(args)
             {
-                Updater = DebugUtils.IsDebugBuild
-                    ? (Game.Updater.Updater) new DummyUpdater()
-                    : (Game.Updater.Updater) new SquirrelUpdater()
+                Updater = !DebugUtils.IsDebugBuild ? new SquirrelUpdater() : null
             };
             
             host.Run(game);

--- a/Qsor.Desktop/Updater/SquirrelUpdater.cs
+++ b/Qsor.Desktop/Updater/SquirrelUpdater.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Reflection;
 using System.Threading;
 using Newtonsoft.Json;

--- a/Qsor.Game/QsorBaseGame.cs
+++ b/Qsor.Game/QsorBaseGame.cs
@@ -6,6 +6,7 @@ using Qsor.Game.Configuration;
 using Qsor.Game.Database;
 using Qsor.Game.Online;
 using Qsor.Game.Overlays;
+using Qsor.Game.Updater;
 
 namespace Qsor.Game
 {
@@ -58,15 +59,15 @@ namespace Qsor.Game
             AddInternal(BeatmapManager);
             AddInternal(NotificationOverlay);
 
-            if (Updater != null)
-            {
-                UpdaterOverlay = new UpdaterOverlay();
+            if (Updater == null)
+                Updater = new DummyUpdater();
+            
+            UpdaterOverlay = new UpdaterOverlay();
                 
-                _dependencies.Cache(UpdaterOverlay);
-                _dependencies.CacheAs(Updater);
+            _dependencies.Cache(UpdaterOverlay);
+            _dependencies.CacheAs(Updater);
                 
-                LoadComponent(Updater);
-            }
+            LoadComponent(Updater);
             
             ConfigManager.Save();
         }

--- a/Qsor.Game/QsorGame.cs
+++ b/Qsor.Game/QsorGame.cs
@@ -1,9 +1,7 @@
-﻿using System.Linq;
-using osu.Framework.Allocation;
+﻿using osu.Framework.Allocation;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osuTK.Input;
 using Qsor.Game.Screens;

--- a/Qsor.Game/Updater/DummyUpdater.cs
+++ b/Qsor.Game/Updater/DummyUpdater.cs
@@ -1,10 +1,9 @@
 ﻿using osu.Framework.Allocation;
-using Qsor.Game.Updater;
 
-namespace Qsor.Desktop.Updater
+namespace Qsor.Game.Updater
 {
    [Cached]
-   public class DummyUpdater : Game.Updater.Updater
+   public class DummyUpdater : Updater
    {
       public override void CheckAvailable()
       {

--- a/Qsor.Tests/Visual/Overlays/TestSceneNotificationOverlay.cs
+++ b/Qsor.Tests/Visual/Overlays/TestSceneNotificationOverlay.cs
@@ -6,7 +6,6 @@ using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osuTK.Graphics;
 using Qsor.Game.Overlays;
-using Qsor.Game.Overlays.Drawables;
 using Qsor.Game.Overlays.Notifications;
 
 namespace Qsor.Tests.Visual.Overlays

--- a/Qsor.Tests/Visual/Overlays/TestSceneUserOverlay.cs
+++ b/Qsor.Tests/Visual/Overlays/TestSceneUserOverlay.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
-using osuTK;
 using Qsor.Game.Online.Users;
 using Qsor.Game.Online.Users.Drawables;
 using Qsor.Game.Overlays;

--- a/Qsor.Tests/Visual/Scenes/MainMenuTestScene.cs
+++ b/Qsor.Tests/Visual/Scenes/MainMenuTestScene.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using Qsor.Game.Screens;
-using Qsor.Game.Screens.Menu;
 
 namespace Qsor.Tests.Visual.Scenes
 {


### PR DESCRIPTION
This is actually a fix to make Qsor.Tests work once again as it's broken in it's current state since an Updater is missing.
